### PR TITLE
Allow sync from html & fix list

### DIFF
--- a/Sources/Commands/List.swift
+++ b/Sources/Commands/List.swift
@@ -23,6 +23,10 @@ extension List {
                             ioctl(STDOUT_FILENO, UInt(TIOCGWINSZ), &w) == 0 ?
                                                          Int(w.ws_col) - 30 : 30)))
             }
+        guard !bookmarklets.isEmpty else {
+            print("No bookmarklet exist")
+            return
+        }
         let titleCol = TextTableColumn(header: "Title".bold)
         let urlCol = TextTableColumn(header: "URL".bold)
         var table = TextTable(columns: [titleCol, urlCol], header: "Bookmarklets".bold)

--- a/Sources/Commands/List.swift
+++ b/Sources/Commands/List.swift
@@ -12,9 +12,17 @@ struct List: ParsableCommand {
 extension List {
     func run() throws {
         var w = winsize()
-        let bookmarklets: [(uuid: String, title: String, url: String)] = (try! Folder(path: Constants.hondanaDirURL + "Bookmarklets/").files.filter { $0.extension == "js" }).map {
-            (uuid: $0.nameExcludingExtension.components(separatedBy: "+").first!, title: $0.nameExcludingExtension.components(separatedBy: "+")[1], url: String(try! $0.readAsString(encodedAs: .utf8).withoutJSPrefix.minified.prefix(ioctl(STDOUT_FILENO, UInt(TIOCGWINSZ), &w) == 0 ? Int(w.ws_col) - 30 : 30)))
-        }
+        let bookmarklets: [(uuid: String, title: String, url: String)] =
+        try Folder(path: Constants.hondanaDirURL).createSubfolderIfNeeded(at: "Bookmarklets/")
+            .files
+            .filter { $0.extension == "js" }
+            .map { (uuid: $0.nameExcludingExtension.components(separatedBy: "+").first!,
+                    title: $0.nameExcludingExtension.components(separatedBy: "+")[1],
+                    url: String(try $0.readAsString(encodedAs: .utf8)
+                        .withoutJSPrefix.minified.prefix(
+                            ioctl(STDOUT_FILENO, UInt(TIOCGWINSZ), &w) == 0 ?
+                                                         Int(w.ws_col) - 30 : 30)))
+            }
         let titleCol = TextTableColumn(header: "Title".bold)
         let urlCol = TextTableColumn(header: "URL".bold)
         var table = TextTable(columns: [titleCol, urlCol], header: "Bookmarklets".bold)

--- a/Sources/Commands/List.swift
+++ b/Sources/Commands/List.swift
@@ -11,31 +11,16 @@ struct List: ParsableCommand {
 
 extension List {
     func run() throws {
-        let file = try! Folder(path: Constants.hondanaDirURL).file(named: "Bookmarks.plist")
-        let data = try! file.read()
-        let decoder = PropertyListDecoder()
-        let settings: Bookmark = try decoder.decode(Bookmark.self, from: data)
-        let root = settings.Children!.filter { child in
-            return child.Children != nil
-        }
         var w = winsize()
-        let bookmarklets = root
-            .compactMap { child in
-                child.Children
-            }
-            .flatMap { $0 }
-            .map {
-                (title: $0.URIDictionary?.title, url: $0.URLString?.prefix(ioctl(STDOUT_FILENO, UInt(TIOCGWINSZ), &w) == 0 ? Int(w.ws_col) - 30 : 30))
-            }
-            .filter {
-                $0.url!.hasPrefix("javascript")
-            }
+        let bookmarklets: [(uuid: String, title: String, url: String)] = (try! Folder(path: Constants.hondanaDirURL + "Bookmarklets/").files.filter { $0.extension == "js" }).map {
+            (uuid: $0.nameExcludingExtension.components(separatedBy: "+").first!, title: $0.nameExcludingExtension.components(separatedBy: "+")[1], url: String(try! $0.readAsString(encodedAs: .utf8).withoutJSPrefix.minified.prefix(ioctl(STDOUT_FILENO, UInt(TIOCGWINSZ), &w) == 0 ? Int(w.ws_col) - 30 : 30)))
+        }
         let titleCol = TextTableColumn(header: "Title".bold)
         let urlCol = TextTableColumn(header: "URL".bold)
         var table = TextTable(columns: [titleCol, urlCol], header: "Bookmarklets".bold)
         
         bookmarklets.forEach { bookmarklet in
-            table.addRow(values: [bookmarklet.title!, String(bookmarklet.url! + "...").red])
+            table.addRow(values: [bookmarklet.title, String(bookmarklet.url + "...").red])
         }
         
         print(table.render())
@@ -45,8 +30,8 @@ extension List {
 extension List {
     enum Constants {
         static let commandName = "list"
-        static let abstract = "`hondana list` lists every bookmarklet present in `Bookmarks.plist`"
-        static let discussion = "`hondana list` accesses to `~/.Hondana/Bookmarks.plist`, reads the plist, and outputs the filtered result in the table."
+        static let abstract = "`hondana list` lists every bookmarklet present in `~/.Hondana/Bookmarklets/`"
+        static let discussion = "`hondana list` accesses to `~/.Hondana/Bookmarklets/`, reads the files in it, and outputs the filtered result in the table."
         
         static let hondanaDirURL = "~/.Hondana/"
     }

--- a/Sources/Commands/Sync.swift
+++ b/Sources/Commands/Sync.swift
@@ -163,8 +163,8 @@ extension Sync {
 extension Sync {
     enum Constants {
         static let commandName = "sync"
-        static let abstract = "`hondana sync` syncs the JavaScript files in `~/.Hondana/Bookmarklets/` with bookmarklets in `~/.Hondana/Bookmarks.plist`"
-        static let discussion = "`hondana sync` first reads the `--from` option to decide whether JavaScript files or Bookmarks.plist should be used as origin. After that, it will read the bookmarklets from the orign to overwrite the ones in the other"
+        static let abstract = "`hondana sync` syncs the JavaScript files in `~/.Hondana/Bookmarklets/` with bookmarklets in browsers"
+        static let discussion = "`hondana sync` first reads the `--from` option to decide which source should be used as origin. After that, it will read the bookmarklets from the orign to sync the bookmarklets"
         
         static let bookmarkletsURL = "Bookmarklets/"
         static let hondanaDirURL = "~/.Hondana/"

--- a/Sources/Commands/Sync.swift
+++ b/Sources/Commands/Sync.swift
@@ -9,21 +9,27 @@ struct Sync: ParsableCommand {
     
     @Option(name: .shortAndLong, help: "Original source for syncing and overwriting bookmarklets in the other.")
     var from: SyncOrigin = .hondanaDir
+    
+    typealias Bookmarklet = (uuid: String, title: String, url: String)
 }
 
 extension Sync {
     func run() throws {
+        let jsContent:  [Bookmarklet]
         switch from {
         case .hondanaDir:
-            let jsContent = readJSContents(from: .hondanaDir)
+            jsContent = readJSContents(from: .hondanaDir)
             write(bookmarklets: jsContent, to: .plist)
         case .plist:
-            let jsContent = readJSContents(from: .plist)
+            jsContent = readJSContents(from: .plist)
+            write(bookmarklets: jsContent, to: .hondanaDir)
+        case .safariHTML:
+            jsContent = readJSContents(from: .safariHTML)
             write(bookmarklets: jsContent, to: .hondanaDir)
         }
     }
     
-    private func readJSContents(from: SyncOrigin) -> [(uuid: String, title: String, url: String)] {
+    private func readJSContents(from: SyncOrigin) -> [Bookmarklet] {
         switch from {
         case .hondanaDir:
             let folder = try! Folder(path: Constants.hondanaDirURL + Constants.bookmarkletsURL)
@@ -54,10 +60,52 @@ extension Sync {
                 }
             
             return bookmarklets
+        case .safariHTML:
+            let file = try! Folder(path: Constants.hondanaDirURL).files.first { $0.extension == "html" }!
+            let html = String(data: try! file.read(), encoding: .utf8)!
+            let htmlRange = NSRange(
+                html.startIndex..<html.endIndex,
+                in: html
+            )
+
+            let regex = "<DT><A HREF=\"javascript:(.+)>(.+)</A>"
+            let captureRegex = try! NSRegularExpression(
+                pattern: regex,
+                options: []
+            )
+            
+            let matches = captureRegex.matches(
+                in: html,
+                options: [],
+                range: htmlRange
+            )
+            let bookmarklets: [Bookmarklet] = matches
+                .compactMap { match in
+                    var arr = [String]()
+                    for rangeIndex in 0..<match.numberOfRanges {
+                        let matchRange = match.range(at: rangeIndex)
+                        
+                        // Ignore matching the entire username string
+                        if matchRange == htmlRange { continue }
+                        
+                        // Extract the substring matching the capture group
+                        if let substringRange = Range(matchRange, in: html) {
+                            let capture = String(html[substringRange])
+                            arr.append(capture)
+                        }
+                    }
+                    
+                    return arr
+                }
+                .map { (arr: [String]) in
+                    (uuid: "", title: arr[2], url: arr[1])
+                }
+
+            return bookmarklets
         }
     }
     
-    private func write(bookmarklets: [(uuid: String, title: String, url: String)], to: SyncOrigin) {
+    private func write(bookmarklets: [Bookmarklet], to: SyncOrigin) {
         switch to {
         case .hondanaDir:
             // FIXME: This will fail when Bookmarklets/ does not exist
@@ -98,6 +146,8 @@ extension Sync {
             if let encoded = try? encoder.encode(settings) {
                 try! file.write(encoded)
             }
+        case .safariHTML:
+            fatalError("This Should Not Be Called")
         }
     }
 }
@@ -106,6 +156,7 @@ extension Sync {
     enum SyncOrigin: String, ExpressibleByArgument {
         case hondanaDir
         case plist
+        case safariHTML
     }
 }
 

--- a/Tests/Fixtures/+test.js
+++ b/Tests/Fixtures/+test.js
@@ -1,0 +1,1 @@
+(alert("testing"))();

--- a/Tests/Fixtures/SafariBookmarks.html
+++ b/Tests/Fixtures/SafariBookmarks.html
@@ -1,0 +1,10 @@
+<!DOCTYPE NETSCAPE-Bookmark-file-1>
+	<HTML>
+	<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+	<Title>ブックマーク</Title>
+	<H1>ブックマーク</H1>
+	<DT><H3 FOLDED>お気に入り</H3>
+	<DL><p>
+		<DT><A HREF="javascript:(alert("testing"))();">test</A>
+	</DL><p>
+</HTML>

--- a/Tests/HondanaTests/HondanaTests.swift
+++ b/Tests/HondanaTests/HondanaTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Files
 import class Foundation.Bundle
 
 import AssertSwiftCLI
@@ -6,6 +7,34 @@ import AssertSwiftCLI
 final class HondanaTests: XCTestCase {
     func testVersionFlag() throws {
         try AssertExecuteCommand(command: "hondana --version", expected: "0.0.6-d")
+    }
+    
+    func testListWithoutJSFiles() throws {
+        try AssertExecuteCommand(command: "hondana list", expected: """
+            +-------------+
+            | Bookmarklets |
+            +-------------+
+            | Title | URL |
+            +-------+-----+
+            
+            +-------+-----+
+            """)
+    }
+    
+    func testListWithJSFiles() throws {
+        let bookmarksHtmlPath = try File(path: #file).parent!.parent!.url.appendingPathComponent("Fixtures/+test.js")
+        try Folder(path: "~/.Hondana/Bookmarklets/").createFile(at: "+test.js", contents: try Data(contentsOf: bookmarksHtmlPath))
+        try AssertExecuteCommand(command: "hondana list", expected: """
+            +-------------------------------------------+
+            | Bookmarklets                              |
+            +-------------------------------------------+
+            | Title | URL                               |
+            +-------+-----------------------------------+
+            | test  | (alert(%22testing%22))()%3B%0A... |
+            +-------+-----------------------------------+
+            """)
+        
+        try File(path: "~/.Hondana/Bookmarklets/+test.js").delete()
     }
 
     /// Returns path to the built products directory.

--- a/Tests/HondanaTests/HondanaTests.swift
+++ b/Tests/HondanaTests/HondanaTests.swift
@@ -5,6 +5,17 @@ import class Foundation.Bundle
 import AssertSwiftCLI
 
 final class HondanaTests: XCTestCase {
+    var hondaDirExistsPrev = false
+    override func setUpWithError() throws {
+        hondaDirExistsPrev = try Folder(path: "~/").containsSubfolder(named: ".Hondana")
+        try Folder(path: "~").createSubfolderIfNeeded(at: ".Hondana").createSubfolderIfNeeded(at: "Bookmarklets")
+    }
+    
+    override func tearDownWithError() throws {
+        guard !hondaDirExistsPrev else { return }
+        try Folder(path: "~/.Hondana").delete()
+    }
+    
     func testVersionFlag() throws {
         try AssertExecuteCommand(command: "hondana --version", expected: "0.0.6-d")
     }

--- a/Tests/HondanaTests/HondanaTests.swift
+++ b/Tests/HondanaTests/HondanaTests.swift
@@ -11,13 +11,7 @@ final class HondanaTests: XCTestCase {
     
     func testListWithoutJSFiles() throws {
         try AssertExecuteCommand(command: "hondana list", expected: """
-            +-------------+
-            | Bookmarklets |
-            +-------------+
-            | Title | URL |
-            +-------+-----+
-            
-            +-------+-----+
+            No bookmarklet exist
             """)
     }
     


### PR DESCRIPTION
This PR will:
- allow syncing from bookmarks.html exported from safari
- fix list to look for js files in `.Hondana/Bookmarklets/`
- add new tests